### PR TITLE
v0.1.0: manually add spawners, remove worker cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [0.1.0] - 2023-06-12
+
+### Added
+
+- Add spawners manually. Manually added spawners are kept out of autoscaling.
+
+### Removed
+
+- Removed worker caching. As it was unoptimized, direct DB lookup performs better.
+
+## [0.0.1] - 2023-06-12
+
+Initial version

--- a/molecule/instance_managers.py
+++ b/molecule/instance_managers.py
@@ -267,9 +267,9 @@ class LocalInstanceManager:
     # create spawner with name instance_name and affinity
     # check if gpu is requested
     if 'gpu' in machine_type and machine_type['gpu'] > 0:
-      spawner_cmd = 'molecule-spawner -o -p {port} -s {store_loc} -mt gpu --storage-type nfs'.format(port=random.randint(2000,9999), store_loc=os.environ.get('store_loc'))
+      spawner_cmd = 'molecule-spawner -o -as -p {port} -s {store_loc} -mt gpu --storage-type nfs'.format(port=random.randint(2000,9999), store_loc=os.environ.get('store_loc'))
     else:
-      spawner_cmd = 'molecule-spawner -o -p {port} -s {store_loc} -mt cpu --storage-type nfs'.format(port=random.randint(2000,9999), store_loc=os.environ.get('store_loc'))
+      spawner_cmd = 'molecule-spawner -o -as -p {port} -s {store_loc} -mt cpu --storage-type nfs'.format(port=random.randint(2000,9999), store_loc=os.environ.get('store_loc'))
     print("Trying to create instance: {}".format(spawner_cmd))
     p = subprocess.Popen(spawner_cmd, shell=True)
     self.process_id_map[instance_name] = str(p.pid)

--- a/molecule/resources.py
+++ b/molecule/resources.py
@@ -106,6 +106,18 @@ class InstanceMetadata:
     except:
       return 'local'
     
+  def getPlatform(self):
+    """
+    This method returns the name of the cloud platform on which the instance is running.
+
+    Args:
+    - None
+
+    Returns:
+    - str: The name of the cloud platform.
+    """
+    return self.cloud_platform
+    
   def getInstanceId(self):
     """
     This method returns the ID of the instance.
@@ -204,9 +216,9 @@ class InstanceMetadata:
     - None
 
     Returns:
-    - str: The number of CPUs of the instance.
+    - int: The number of CPUs of the instance.
     """
-    return str(os.cpu_count())
+    return os.cpu_count() or 0
   
   def getMemory(self):
     """

--- a/molecule/server.py
+++ b/molecule/server.py
@@ -310,8 +310,8 @@ class Server:
         log.info("COMMAND_CONNECT Recieved")
         log.info(wi)
         ZMQServer.sendACK(self.command_sock, MessageBase.ACK_CONNECT)
-        # # TODO: Check if addWorkerInDB is needed here?
-        # self.db.addWorkerInDB(wi, WorkerStatus.INITIATED)
+        if not self.db.checkWorkerExistsInDB(wi['instance_id']):
+          self.db.addWorkerInDB(wi, WorkerStatus.INITIATED)
         self.db.updateWorkerPorts(wi['instance_id'], wi['port'], wi['health_port'])
         self.db.updateWorkerInDB(wi['instance_id'], WorkerStatus.FREE, task_hash='')
         log.info('Spawner Added: ' + wi['instance_id'])
@@ -402,8 +402,7 @@ class Server:
           self.processTransforms()
           self.requestWorkers()
         except Exception as err:
-          log.critical('Encountered fatal error, did you do something shady?')
-          log.debug('Meh, I won\'t go down so easily! :3')
+          log.critical('Encountered fatal error, check logs and restart platform!')
           self.db.pushNotification(0, 'Fatal Error', 'Check logs and restart platform!')
           print(err)
           print(traceback.format_exc())

--- a/molecule/start_platform.py
+++ b/molecule/start_platform.py
@@ -50,7 +50,7 @@ class StartPlatform:
     """
     Initializes the database.
     """
-    self.db = database.Database(self.db_env, rebuild=True)
+    self.db = database.Database(self.db_env)
 
   def startServer(self):
     """

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,9 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as f:
     long_description = f.read()
 
-# list of packages to be installed
-# pyyaml==5.3.1 google-cloud-logging google-cloud-storage google-cloud-bigquery zmq flask==2.2.2 flask_cors python-crontab pandas pyarrow gcsfs pymongo Flask-PyMongo
-
 setup(
     name="molecule",
-    version="0.0.1",
+    version="0.1.0",
     description="An scalable ML Platform to help you build, train, and deploy models",
     packages=find_packages(),
     long_description=long_description,


### PR DESCRIPTION
- Add spawners manually. Manually added spawners are kept out of autoscaling.
- Removed worker caching. As it was unoptimized, direct DB lookup performs better.